### PR TITLE
Use lark 1.0+

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ classifier =
 include_package_data = true
 python_requires = >= 3.6
 packages = find:
-install_requires = lark-parser>=0.11.2
+install_requires = lark>=1.0.0
 
 [options.package_data]
 grascii = 


### PR DESCRIPTION
This PR switches `lark-parser` to the new `lark` package name for version 1.0.0+. Upgrading will allow for the use of more features.