### PR TITLE
Restrict contain searches to the grascii word

### DIFF
--- a/grascii/regen.py
+++ b/grascii/regen.py
@@ -121,11 +121,10 @@ class RegexBuilder():
         aspirate = "(" + re.escape(grammar.ASPIRATE) + ")"
         disjoiner = "(" + re.escape(grammar.DISJOINER) + ")"
 
-        builder = list()
+        builder = list("^")
         i = 0
         if self.search_mode is SearchMode.MATCH or \
                 self.search_mode is SearchMode.START:
-            builder.append("^")
             if self.aspirate_mode is Strictness.LOW:
                 builder.append(aspirate)
                 builder.append("?")
@@ -138,7 +137,7 @@ class RegexBuilder():
                     builder.append("?")
 
         if self.search_mode is SearchMode.CONTAIN:
-            builder.append(".*")
+            builder.append(r"\S*")
 
         found_first = False
 

--- a/tests/test_regen.py
+++ b/tests/test_regen.py
@@ -472,10 +472,11 @@ class TestSearchMode(unittest.TestCase):
         ]
         self.run_tests(builder, tests)
 
-    def test_contains(self):
+    def test_contain(self):
         builder = regen.RegexBuilder(search_mode=regen.SearchMode.CONTAIN)
         tests = [
-            (["A", "B"], [("AB", True), ("ABU", True), ("DAB", True)])
+            (["A", "B"], [("AB", True), ("ABU", True), ("DAB", True)]),
+            (["X"], [("ANEX Annex", True), ("VEXN Vixen", True), ("ZANTHUS Xanthous", False), ("ZEBK Xebec", False), ("ZEBK xebec", False), ("ZEBK eXbec", False), ("ZEBK ebec abXD", False)])
         ]
         self.run_tests(builder, tests)
 


### PR DESCRIPTION
This fixes #14 by ensuring that the regex generated for contain searches only matches the grascii word (the first word in the dictionary entry).