### PR TITLE
Add GrasciiValidator

### DIFF
--- a/grascii/__init__.py
+++ b/grascii/__init__.py
@@ -1,1 +1,2 @@
+APP_NAME = "grascii"
 __version__ = "0.4.0"

--- a/grascii/config.py
+++ b/grascii/config.py
@@ -10,9 +10,9 @@ from pathlib import Path, PurePath
 from shutil import copyfile
 import sys
 
+from grascii import APP_NAME
 from grascii.appdirs import user_config_dir
 
-APP_NAME = "grascii"
 CONF_DIRECTORY = user_config_dir(APP_NAME)
 CONF_FILE_NAME = APP_NAME + ".conf"
 

--- a/grascii/dictionary/build.py
+++ b/grascii/dictionary/build.py
@@ -22,6 +22,7 @@ except ImportError:
     pass
 
 from grascii import defaults, grammar
+from grascii.parser import GrasciiValidator
 from grascii.utils import get_grammar, get_words_file
 
 description = "Build a Grascii Dictionary"
@@ -160,7 +161,10 @@ class DictionaryBuilder():
         """Load a parser to check grascii strings."""
 
         if self.parse:
-            self.parser = Lark(get_grammar("grascii"), parser="earley", ambiguity="forest")
+            # Disable cache for now
+            # It could be enabled, but we have to be careful about clearing the
+            # cache after grammar changes
+            self.parser = GrasciiValidator(use_cache=False)
 
     def load_word_set(self) -> None:
         """Load a set of words to check the spelling of words."""
@@ -212,9 +216,7 @@ class DictionaryBuilder():
         """
 
         if self.parse:
-            try:
-                self.parser.parse(grascii)
-            except UnexpectedInput:
+            if not self.parser.validate(grascii):
                 self.log_error(file_name, line, line_number, "Failed to parse", grascii)
                 return False
         return True


### PR DESCRIPTION
This adds a `GrasciiValidator` class that uses the LALR parser to validate Grascii strings. Using LALR is much faster than Earley. However, LALR should not be used to interpret Grascii strings because it will not produce the best interpretation.
The PR also changes the dictionary builder to use `GrasciiValidator` for the `--parse` option. This provides over a 50x speedup when building the preanniversary dictionary.