### PR TITLE
Make common objects importable from grascii

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,3 +26,4 @@ repos:
     rev: 3.7.9
     hooks:
     - id: flake8
+      exclude: grascii/__init__.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Some classes and functions that are considered to be part of the public API are importable from the top-level `grascii`.
+
 ## 0.4.0 - 2022-06-27
 
 ### Added

--- a/grascii/__init__.py
+++ b/grascii/__init__.py
@@ -1,2 +1,12 @@
 APP_NAME = "grascii"
-__version__ = "0.4.0"
+__version__ = "0.4.1"
+
+from grascii.dictionary.build import BuildMessage, DictionaryBuilder
+from grascii.parser import (
+    GrasciiParser,
+    GrasciiValidator,
+    Interpretation,
+    interpretation_to_string,
+)
+from grascii.regen import SearchMode, Strictness
+from grascii.searchers import GrasciiSearcher, RegexSearcher, ReverseSearcher, Searcher


### PR DESCRIPTION
Makes some classes and functions that are considered to be part of the public api importable from the top-level `grascii`.