### PR TITLE
Enable coverage for interactive tests

### DIFF
--- a/grascii/__main__.py
+++ b/grascii/__main__.py
@@ -3,12 +3,20 @@
 from __future__ import annotations
 
 import argparse
+import signal
 import sys
 
 from grascii import config, dictionary, search
 
 
 def main() -> None:
+    try:
+        from pytest_cov.embed import cleanup_on_signal
+    except ImportError:
+        pass
+    else:
+        cleanup_on_signal(signal.SIGHUP)
+
     argparser = argparse.ArgumentParser(prog="grascii")
     subparsers = argparser.add_subparsers(title="subcommands")
     argparser.set_defaults(func=None)

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -31,7 +31,7 @@ class InteractiveTester(unittest.TestCase):
         )
 
     def tearDown(self):
-        self.c.close(force=True)
+        self.c.terminate(force=True)
 
     def expect(self, patterns):
         return self.c.expect([pexpect.TIMEOUT] + patterns, timeout=5)


### PR DESCRIPTION
Allows for code coverage reporting for tests that use `pexpect` by making sure that code coverage data is flushed from pexpect spawns.