### PR TITLE
Fix dephrase for SearchResults

### DIFF
--- a/grascii/dephrase.py
+++ b/grascii/dephrase.py
@@ -86,10 +86,10 @@ class PhraseFlattener(Transformer):
 
     @lru_cache(maxsize=32)
     def _search_grascii(self, grascii_str):
-        results = self._grascii_searcher.search(grascii=grascii_str)
+        results = self._grascii_searcher.sorted_search(grascii=grascii_str)
         if not results:
             raise NoWordFound()
-        words = [result.split()[1].upper() for result in results]
+        words = (result.entry.translation.upper() for result in results)
         string = "(" + "|".join(words) + ")"
         return self.create_token(string)
 
@@ -136,7 +136,7 @@ def dephrase(**kwargs) -> Set[str]:
         except VisitError as e:
             if isinstance(e.orig_exc, NoWordFound):
                 continue
-            raise e
+            raise e  # no cov
         else:
             parses.add(" ".join(tokens))
     return parses

--- a/tests/test_phrasing.py
+++ b/tests/test_phrasing.py
@@ -6,7 +6,7 @@ import unittest
 from lark import Lark
 from lark.visitors import CollapseAmbiguities
 
-from grascii.dephrase import PhraseFlattener
+from grascii.dephrase import PhraseFlattener, dephrase
 from grascii.grammars import get_grammar
 
 
@@ -109,6 +109,10 @@ class TestLessonPhrases(unittest.TestCase):
     @unittest.skip("fix these later")
     def test_lesson19a(self):
         self._test_lesson("19a")
+
+
+def test_aggressive():
+    dephrase(phrase="thlnbg", aggressive=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This fixes aggressive dephrasing which was broken by changes in #39.