### PR TITLE
Add InvalidGrascii Exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 - `grascii.dictionary.common` module to contain `DictionaryException`s and utility functions.
 - `Dictionary` class to work with grascii dictionaries.
 - `config.get_default_config` to get the text of the default configuration file.
-- `-V` and `--version` command line options
+- `-V` and `--version` command line options.
+- `InvalidGrascii` exception which is produced by a parser.
 
 ### Changed
 

--- a/grascii/__init__.py
+++ b/grascii/__init__.py
@@ -8,6 +8,7 @@ from grascii.parser import (
     GrasciiParser,
     GrasciiValidator,
     Interpretation,
+    InvalidGrascii,
     interpretation_to_string,
 )
 from grascii.regen import SearchMode, Strictness

--- a/grascii/interactive.py
+++ b/grascii/interactive.py
@@ -14,12 +14,10 @@ except ImportError:
 import sys
 from typing import Callable, Iterable, List, Optional, Sequence, Tuple, TypeVar
 
-from lark import UnexpectedInput
-
 from grascii import regen
 from grascii.dictionary import Dictionary
 from grascii.dictionary.list import get_built_ins, get_installed
-from grascii.parser import Interpretation, interpretation_to_string
+from grascii.parser import Interpretation, InvalidGrascii, interpretation_to_string
 from grascii.searchers import GrasciiSearcher
 
 T = TypeVar("T")
@@ -302,9 +300,9 @@ class InteractiveSearcher(GrasciiSearcher):
             search = search.upper()
             try:
                 interpretations = self._parser.interpret(search)
-            except UnexpectedInput as e:
+            except InvalidGrascii as e:
                 print("Invalid Grascii String", file=sys.stderr)
-                print(e.get_context(search), file=sys.stderr)
+                print(e.context, file=sys.stderr)
                 previous = search
                 continue
             return search, interpretations

--- a/grascii/parser.py
+++ b/grascii/parser.py
@@ -110,13 +110,23 @@ class GrasciiValidator:
             return False
 
 
+class InvalidGrascii(Exception):
+    def __init__(self, grascii: str, unexpected_input: UnexpectedInput) -> None:
+        self.grascii = grascii
+        self.unexpected_input = unexpected_input
+        self.context = unexpected_input.get_context(grascii)
+
+
 class GrasciiParser:
     def __init__(self) -> None:
         grammar = get_grammar("grascii")
         self._parser: Lark = Lark.open(grammar, parser="earley", ambiguity="explicit")
 
     def parse(self, grascii: str) -> Tree:
-        return self._parser.parse(grascii)
+        try:
+            return self._parser.parse(grascii)
+        except UnexpectedInput as ui:
+            raise InvalidGrascii(grascii, ui)
 
     def interpret(
         self, grascii: str, preserve_boundaries: bool = False

--- a/grascii/search.py
+++ b/grascii/search.py
@@ -12,6 +12,7 @@ import sys
 from typing import Iterable, Optional
 
 from grascii import regen
+from grascii.parser import InvalidGrascii
 from grascii.searchers import GrasciiSearcher, RegexSearcher, ReverseSearcher, Searcher
 
 SUPPORTS_INTERACTIVE = False
@@ -133,11 +134,17 @@ def cli_search(args: argparse.Namespace) -> None:
     :param args: A namespace of parsed arguments.
     """
 
-    results = search(**{k: v for k, v in vars(args).items() if v is not None})
-    if results is not None:
-        for result in results:
-            print(result.entry.grascii, result.entry.translation)
-        print("Results:", len(results))
+    try:
+        results = search(**{k: v for k, v in vars(args).items() if v is not None})
+    except InvalidGrascii as e:
+        print("Invalid Grascii String", file=sys.stderr)
+        print(e.context, file=sys.stderr)
+        return
+    else:
+        if results is not None:
+            for result in results:
+                print(result.entry.grascii, result.entry.translation)
+            print("Results:", len(results))
 
 
 def main() -> None:

--- a/grascii/searchers.py
+++ b/grascii/searchers.py
@@ -5,7 +5,6 @@ implementations of it.
 from __future__ import annotations
 
 import re
-import sys
 from abc import ABC, abstractmethod
 from typing import (
     TYPE_CHECKING,
@@ -23,8 +22,6 @@ from typing import (
     Tuple,
     TypeVar,
 )
-
-from lark.exceptions import UnexpectedInput
 
 from grascii import defaults, grammar, metrics, regen
 from grascii.dictionary import Dictionary, DictionaryNotFound
@@ -212,12 +209,7 @@ class GrasciiSearcher(Searcher[Interpretation]):
         grascii = kwargs["grascii"].upper()
         self.extract_search_args(**kwargs)
 
-        try:
-            interpretations = self._parser.interpret(grascii)
-        except UnexpectedInput as e:
-            print("Invalid Grascii String", file=sys.stderr)
-            print(e.get_context(grascii), file=sys.stderr)
-            return None
+        interpretations = self._parser.interpret(grascii)
 
         builder = regen.RegexBuilder(
             uncertainty=self.uncertainty,

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -241,6 +241,12 @@ class TestSearch(InteractiveTester):
         self.c.sendline()
         self.assertGreater(self.expect(["AB"]), 0)
 
+    def test_invalid_grascii(self):
+        self.new_search()
+        self.assertGreater(self.expect(["Enter Search:"]), 0)
+        self.c.sendline("rac")
+        self.assertGreater(self.expect(["Invalid Grascii"]), 0)
+
 
 class TestCancel(InteractiveTester):
     def test_main_menu(self):

--- a/tests/test_searchers.py
+++ b/tests/test_searchers.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from shutil import rmtree
 
 from grascii.dictionary.build import DictionaryBuilder
+from grascii.parser import InvalidGrascii
 from grascii.searchers import GrasciiSearcher, ReverseSearcher
 
 output_dir = "tests/dictionaries/tosearch"
@@ -65,6 +66,15 @@ class TestGrasciiSearcher(unittest.TestCase):
         )
         self.assertGreater(start_count, match_count)
         self.assertGreater(contain_count, start_count)
+
+    def test_invalid_grascii(self):
+        searcher = GrasciiSearcher(dictionaries=[output_dir])
+        with self.assertRaises(InvalidGrascii):
+            searcher.sorted_search(grascii="RAC")
+        with self.assertRaises(InvalidGrascii):
+            searcher.sorted_search(grascii="WAY")
+        with self.assertRaises(InvalidGrascii):
+            searcher.sorted_search(grascii="YES")
 
 
 class TestReverseSearcher(unittest.TestCase):


### PR DESCRIPTION
This adds `InvalidGrascii` exception that is raised by `GrasciiParser`. It's introduction allows the removing of console error reporting from `GrasciiSearcher`.