### PR TITLE
Add --no-sort search option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `config.get_default_config` to get the text of the default configuration file.
 - `-V` and `--version` command line options.
 - `InvalidGrascii` exception which is produced by a parser.
+- `--no-sort` option for `grascii search`.
 
 ### Changed
 
@@ -21,6 +22,7 @@ installed dictionary names (prefixed with `:`).
 - `grascii.dictionary.install.install_dict` renamed to `install_dictionary` and accepts more options.
 - `grascii.dictionary.uninstall.uninstall_dict` renamed to `uninstall_dictionary` and accepts more options.
 - `DICTIONARY_PATH` renamed to `INSTALLATION_DIR`.
+- Using builtin `sorted` function speeds up general grascii searches.
 
 ### Removed
 

--- a/grascii/interactive.py
+++ b/grascii/interactive.py
@@ -14,7 +14,7 @@ except ImportError:
 import sys
 from typing import Callable, Iterable, List, Optional, Sequence, Tuple, TypeVar
 
-from grascii import regen
+from grascii import metrics, regen
 from grascii.dictionary import Dictionary
 from grascii.dictionary.list import get_built_ins, get_installed
 from grascii.parser import Interpretation, InvalidGrascii, interpretation_to_string
@@ -57,6 +57,7 @@ class InteractiveSearcher(GrasciiSearcher):
         """
 
         self.extract_search_args(**kwargs)
+        self.sort = not kwargs.get("no_sort")
         self.run_interactive()
 
     def choose_interpretation(
@@ -259,6 +260,8 @@ class InteractiveSearcher(GrasciiSearcher):
         patterns = builder.generate_patterns_map(interps)
         starting_letters = builder.get_starting_letters(interps)
         results = self.perform_search(patterns, starting_letters)
+        if self.sort:
+            results = sorted(results, key=lambda r: metrics.grascii_standard(r))
         count = 0
         display_all = False
         for result in results:

--- a/grascii/searchers.py
+++ b/grascii/searchers.py
@@ -119,17 +119,10 @@ class Searcher(ABC, Generic[IT]):
         **kwargs: Any,
     ) -> Sequence[SearchResult[IT]]:
 
-        results = []
         search_results = self.search(**kwargs)
         if search_results:
-            for result in search_results:
-                results.append((result, metric(result)))
-                i = len(results) - 1
-                while i > 0:
-                    if results[i][1] < results[i - 1][1]:
-                        results[i - 1], results[i] = results[i], results[i - 1]
-                    i -= 1
-        return [result for result, _ in results]
+            return sorted(search_results, key=lambda r: metric(r))
+        return []
 
 
 class GrasciiSearcher(Searcher[Interpretation]):


### PR DESCRIPTION
This PR adds a `--no-sort` option to `grascii search` and makes sorted searches the default behavior for all searches, including interactive. Closes #43.