### PR TITLE
Regex grammar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ grascii.conf
 build/
 dist/
 grascii.egg-info/
+grascii/grammars/grascii_regex.lark

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 recursive-include grascii *.lark
+exclude grascii/grammars/grascii_regex.lark
 include grascii/defaults.conf
 prune grascii/dictionary/preanniversary
 
@@ -11,6 +12,7 @@ recursive-include docs/images *.png
 prune docs/reference
 include docs/conf.py docs/make.bat
 
+recursive-include scripts *.py
 recursive-include tests *.py *.txt
 include *.md
 include *.yaml

--- a/create_grascii_regex.py
+++ b/create_grascii_regex.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from lark import Lark, Token, Transformer, Tree
+from lark.reconstruct import Reconstructor
+
+
+class GrasciiProcessor(Transformer):
+    def __init__(self, parser):
+        super().__init__(visit_tokens=True)
+        self.parser = parser
+
+    def start(self, children):
+        # insert a new start rule
+        new_start = self.parser.parse("start: GRASCII", start="rule")
+        return Tree(
+            "start", [new_start, Token("_NL", "\n"), Token("_NL", "\n")] + children
+        )
+
+    def rule(self, children):
+        if children[0] == "_STRING":
+            # insert a nonrecursive definition of _string
+            new_string = self.parser.parse(
+                "_STRING: _LETTER (ASPIRATE? (BOUNDARY | INTERSECTION)? _LETTER)*",
+                start="token",
+            )
+            return new_string
+        return Tree("token", children)
+
+    def rule_params(self, children):
+        return Tree("token_params", children)
+
+    def RULE(self, token):
+        if token == "start":
+            # rename the start rule to a token
+            return Token("TOKEN", "GRASCII")
+        # change all rules to tokens
+        return Token("TOKEN", token.upper())
+
+
+def postproc(strings):
+    """Insert necessary spaces back into the lark grammar"""
+    prev = ""
+    for item in strings:
+        if getattr(prev, "type", "") == "OP" and getattr(item, "type", "") in {
+            "RULE",
+            "TOKEN",
+        }:
+            yield " "
+        yield item
+        prev = item
+
+
+def create_grascii_regex():
+    parser = Lark.open_from_package(
+        "lark",
+        "grammars/lark.lark",
+        maybe_placeholders=False,
+        parser="lalr",
+        start=["start", "token", "rule"],
+        keep_all_tokens=True,
+    )
+
+    tree = parser.parse(
+        Path("grascii/grammars/grascii.lark").read_text(), start="start"
+    )
+    tree = GrasciiProcessor(parser).transform(tree)
+
+    reconstructor = Reconstructor(parser)
+    grammar = reconstructor.reconstruct(tree, postproc)
+    Path("grascii/grammars/grascii_regex.lark").write_text(grammar)
+
+
+if __name__ == "__main__":
+    create_grascii_regex()

--- a/grascii/dictionary/build.py
+++ b/grascii/dictionary/build.py
@@ -236,7 +236,7 @@ class DictionaryBuilder:
             # Disable cache for now
             # It could be enabled, but we have to be careful about clearing the
             # cache after grammar changes
-            self.parser = GrasciiValidator(use_cache=False)
+            self.parser = GrasciiValidator()
             logger.info("Created GrasciiValidator")
 
     def _load_word_set(self) -> None:

--- a/scripts/build_dictionaries.py
+++ b/scripts/build_dictionaries.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from grascii import dictionary
+
+
+def check_submodule():
+    if not Path("dictionaries/builtins").exists():
+        logging.critical(
+            "dictionaries/builtins does not exist. "
+            + "Has the submodule been checked out?\n"
+            + "Try: git submodule update --init"
+        )
+        raise RuntimeError("Missing dictionary build requirements")
+
+
+def build_dictionaries():
+    check_submodule()
+    dictionary.build.build(
+        infiles=Path("dictionaries/builtins/preanniversary").glob("*.txt"),
+        output=Path("grascii/dictionary/preanniversary"),
+        package=True,
+    )
+
+
+if __name__ == "__main__":
+    build_dictionaries()

--- a/scripts/create_grascii_regex.py
+++ b/scripts/create_grascii_regex.py
@@ -70,6 +70,8 @@ def create_grascii_regex():
     reconstructor = Reconstructor(parser)
     grammar = reconstructor.reconstruct(tree, postproc)
     Path("grascii/grammars/grascii_regex.lark").write_text(grammar)
+    print("Created grascii/grammars/grascii_regex.lark")
+    print(grammar)
 
 
 if __name__ == "__main__":

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,12 +5,12 @@ version = attr: grascii.__version__
 description = A language with tools to facilitate the study of Gregg Shorthand.
 long_description = file: docs/README.rst
 author = Chanic Panic
-author-email = dev@chanicpanic.com
+author_email = dev@chanicpanic.com
 url = https://github.com/grascii/grascii
 license = MIT
 license_files = LICENSE.txt
 platform = any
-requires-dist = setuptools
+requires_dist = setuptools
 keywords = shorthand, gregg shorthand, dictionary
 classifier =
   Development Status :: 3 - Alpha

--- a/setup.py
+++ b/setup.py
@@ -2,33 +2,18 @@
 
 from __future__ import annotations
 
-import logging
-from pathlib import Path
-
 from setuptools import setup
 from setuptools.command.build_py import build_py
 
-from grascii import dictionary
+from scripts.build_dictionaries import build_dictionaries
+from scripts.create_grascii_regex import create_grascii_regex
 
 
-class DictionaryBuild(build_py):
+class PreBuild(build_py):
     def run(self):
-        self._check_submodule()
-        dictionary.build.build(
-            infiles=Path("dictionaries/builtins/preanniversary").glob("*.txt"),
-            output=Path("grascii/dictionary/preanniversary"),
-            package=True,
-        )
+        build_dictionaries()
+        create_grascii_regex()
         build_py.run(self)
 
-    def _check_submodule(self):
-        if not Path("dictionaries/builtins").exists():
-            logging.critical(
-                "dictionaries/builtins does not exist. "
-                + "Has the submodule been checked out?\n"
-                + "Try: git submodule update --init"
-            )
-            raise RuntimeError("Missing dictionary build requirements")
 
-
-setup(cmdclass={"build_py": DictionaryBuild})
+setup(cmdclass={"build_py": PreBuild})


### PR DESCRIPTION
This PR adds a script to create `grascii_regex.lark` from `grascii.lark`. `grascii_regex.lark` consists of only terminals so that a regular expression that matches an entire grascii string is generated by Lark.

Using a regex for grascii validation is about 5x faster than using the LALR parser. Validating the entire preanniversary dictionary went from ~2.5s to ~0.5s.