### PR TITLE
Ambig tools

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
-exclude: tests/dictionaries/comments.txt|grascii/appdirs.py
+exclude: tests/dictionaries/comments.txt|grascii/appdirs.py|grascii/lark_ambig_tools.py
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - `-V` and `--version` command line options.
 - `InvalidGrascii` exception which is produced by a parser.
 - `--no-sort` option for `grascii search`.
+- `grascii.parser.get_grascii_regex_str()` to get a string that can be compiled into
+  a regular expression that recognizes grascii strings.
 
 ### Changed
 
@@ -23,11 +25,13 @@ installed dictionary names (prefixed with `:`).
 - `grascii.dictionary.uninstall.uninstall_dict` renamed to `uninstall_dictionary` and accepts more options.
 - `DICTIONARY_PATH` renamed to `INSTALLATION_DIR`.
 - Using builtin `sorted` function speeds up general grascii searches.
+- `GrasciiParser.interpret` returns an iterator instead of a list.
 
 ### Removed
 
 - Dropped Python 3.6 support.
 - `grascii.dictionary.get_dict_file`: Use `grascii.dictionary.Dictionary.open` instead.
+- `GrasciiValidator.__init__` `use_cache` option
 
 ### Fixed
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,7 +32,7 @@ master_doc = "index"
 # ones.
 extensions = ["sphinx_rtd_theme", "sphinx.ext.autodoc", "sphinxcontrib.apidoc"]
 apidoc_module_dir = "../grascii"
-apidoc_excluded_paths = ["../grascii/appdirs.py"]
+apidoc_excluded_paths = ["../grascii/appdirs.py", "../grascii/lark_ambig_tools.py"]
 apidoc_output_dir = "reference"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/grascii/dephrase.py
+++ b/grascii/dephrase.py
@@ -6,9 +6,10 @@ from functools import lru_cache
 from typing import Set
 
 from lark import Lark, Token, Transformer, UnexpectedInput
-from lark.visitors import CollapseAmbiguities, VisitError, v_args
+from lark.visitors import VisitError, v_args
 
 from grascii.grammars import get_grammar
+from grascii.lark_ambig_tools import Disambiguator
 from grascii.parser import GrasciiFlattener, interpretation_to_string
 from grascii.searchers import GrasciiSearcher
 
@@ -128,7 +129,7 @@ def dephrase(**kwargs) -> Set[str]:
     except UnexpectedInput:
         return parses
 
-    trees = CollapseAmbiguities().transform(tree)
+    trees = Disambiguator().visit(tree)
     for t in trees:
         try:
             tokens = (token.type for token in trans.transform(t))
@@ -148,7 +149,7 @@ def cli_dephrase(args: argparse.Namespace) -> None:
             "an excessively long time to process and produce many",
             "irrelevant results.",
         )
-        print("To ignore this warning use '--ignore_limit'.")
+        print("To ignore this warning use '--ignore-limit'.")
         return
     results = dephrase(**{k: v for k, v in vars(args).items() if v is not None})
     if results:

--- a/grascii/interactive.py
+++ b/grascii/interactive.py
@@ -302,7 +302,7 @@ class InteractiveSearcher(GrasciiSearcher):
                 continue
             search = search.upper()
             try:
-                interpretations = self._parser.interpret(search)
+                interpretations = list(self._parser.interpret(search))
             except InvalidGrascii as e:
                 print("Invalid Grascii String", file=sys.stderr)
                 print(e.context, file=sys.stderr)

--- a/grascii/lark_ambig_tools.py
+++ b/grascii/lark_ambig_tools.py
@@ -1,0 +1,142 @@
+"""
+MIT License
+
+Copyright (c) 2022 chanicpanic
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+import sys
+from functools import reduce
+from itertools import chain, product, repeat
+from typing import Any, Collection, Iterable, Iterator, Tuple, TypeVar
+
+from lark import Tree, Transformer
+from lark.visitors import Interpreter
+
+if sys.version_info >= (3, 8):
+    from math import prod
+else:
+
+    def prod(nums, start=1):
+        return reduce(lambda x, y: x * y, nums, start)
+
+
+T = TypeVar("T")
+
+
+class CountedTree(Tree):
+    """A tree subclass with an additional attribute, ``derivation_count``, that
+    represents the total number of possible derivations of this tree.
+    Derivations are counted based on the number and position of '_ambig' nodes.
+
+    Take caution using the constructor directly. All tree children must be
+    instances of ``CountedTree`` for the derivation count to be accurate.
+    Changing the children after construction will not update the derivation count.
+    """
+    def __init__(self, data, children, meta=None):
+        super().__init__(data, children, meta)
+        derivation_counts = map(_get_derivation_count, children)
+        self.derivation_count = (sum(derivation_counts) if data == "_ambig" else prod(derivation_counts))
+
+
+class CountTrees(Transformer):
+    """A transformer that transforms a ``Tree`` into a ``CountedTree``."""
+    def __default__(self, data, children, meta):
+        return CountedTree(data, children, meta)
+
+
+def _get_derivation_count(tree: Any) -> int:
+    return getattr(tree, "derivation_count", 1)
+
+
+def _repeat_each(iterable: Iterable[T], n: int) -> Iterator[T]:
+    """Repeat each element of the iterable n times.
+
+    Recipe from more-itertools: https://github.com/more-itertools/more-itertools
+    """
+    return chain.from_iterable(map(repeat, iterable, repeat(n)))
+
+
+def _ncycles(iterable: Iterable[T], n: int) -> Iterator[T]:
+    """Return the elements of the iterable n times.
+
+    This implementation evaluates the elements of the iterable lazily.
+    """
+    if n > 0:
+        saved = []
+        for element in iterable:
+            yield element
+            saved.append(element)
+        yield from chain.from_iterable(repeat(saved, n - 1))
+
+
+def _lazy_product(iterables: Collection[Iterable[T]], lengths: Collection[int]) -> Iterator[Tuple[T, ...]]:
+    """Return the Cartesian Product of the iterables of the given lengths.
+
+    This implementation takes advantage of the known lengths of the iterables
+    to evaluate the iterables lazily in contrast to ``itertools.product``.
+    This function generates tuples in the same order as ``itertools.product``.
+
+    Preconditions: ``len(iterables) == len(lengths)`` and ``lengths[i]`` is the
+    number of calls of `next` on an iterator of `iterables[i]` before
+    ``StopIteration`` is raised.
+    """
+    cycle_count = 1
+    repeat_count = prod(lengths)
+    iterators = []
+    for iterable, length in zip(iterables, lengths):
+        repeat_count //= length
+        iterators.append(_ncycles(_repeat_each(iterable, repeat_count), cycle_count))
+        cycle_count *= length
+    return zip(*iterators)
+
+
+class Disambiguator(Interpreter):
+    """An Interpreter that iterates over the unambiguous derivations of an
+    ambiguous tree (one containing '_ambig' nodes).
+
+    By lazily constructing trees, ``Disambiguator`` is more computationally and
+    memory efficient than ``lark.visitors.CollapseAmbiguities``.
+
+    When visiting a ``CountedTree``, ``Disambiguator`` takes advantage of the
+    known derivation counts to be even more lazy and is ideal for the case in
+    which you only need to find one tree that meets your requirements.
+
+    If you are always going to iterate over all possible derivations, it is
+    slightly faster to visit a regular ``Tree``.
+    """
+    def _ambig(self, tree: Tree) -> Iterator[Tree]:
+        for child in tree.children:
+            yield from self.visit(child)
+
+    def __default__(self, tree: Tree) -> Iterator[Tree]:
+        if isinstance(tree, CountedTree) and tree.derivation_count == 1:
+            yield tree
+        else:
+            yield from self._generate_subtrees(tree)
+
+    def _generate_subtrees(self, tree: Tree) -> Iterator[Tree]:
+        sub_tree_iterators = [self.visit(child) if isinstance(child, Tree) else (child,) for child in tree.children]
+        if isinstance(tree, CountedTree):
+            derivation_counts = [_get_derivation_count(child) for child in tree.children]
+            children_lists = _lazy_product(sub_tree_iterators, derivation_counts)
+        else:
+            children_lists = product(*sub_tree_iterators)
+        for children_list in children_lists:
+            yield Tree(tree.data, list(children_list))

--- a/grascii/searchers.py
+++ b/grascii/searchers.py
@@ -214,9 +214,9 @@ class GrasciiSearcher(Searcher[Interpretation]):
         )
 
         interps = (
-            interpretations[0:1]
+            [next(interpretations)]
             if self.interpretation_mode == "best"
-            else interpretations
+            else list(interpretations)
         )
         patterns = builder.generate_patterns_map(interps)
         starting_letters = builder.get_starting_letters(interps)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ branch = true
 parallel = true
 omit = [
   "grascii/appdirs.py",
+  "grascii/lark_ambig_tools.py",
   "tests/*",
 ]
 

--- a/tests/test_outline.py
+++ b/tests/test_outline.py
@@ -13,9 +13,9 @@ class TestInferredDirections(unittest.TestCase):
     def run_tests(self, tests):
         for test in tests:
             with self.subTest(word=test[0], expected=test[1]):
-                interpretation = self.parser.interpret(
-                    test[0], preserve_boundaries=True
-                )[0]
+                interpretation = next(
+                    self.parser.interpret(test[0], preserve_boundaries=True)
+                )
                 outline = Outline(interpretation)
                 self.assertEqual(str(outline), test[1])
 
@@ -341,9 +341,9 @@ class TestToInterpretation(unittest.TestCase):
         ]
         for test in tests:
             with self.subTest(word=test[0], expected=test[1]):
-                interpretation = self.parser.interpret(
-                    test[0], preserve_boundaries=True
-                )[0]
+                interpretation = next(
+                    self.parser.interpret(test[0], preserve_boundaries=True)
+                )
                 outline = Outline(interpretation)
                 self.assertEqual(
                     interpretation_to_string(outline.to_interpretation()), test[1]


### PR DESCRIPTION
This PR brings in [lark-ambig-tools](https://github.com/chanicpanic/lark-ambig-tools) and replaces usages of `CollapseAmbiguities` with `Disambiguator`. This change should improve the performance of `--interpretation=best` for grascii strings with many interpretations and the performance of the dephraser.