### PR TITLE
Improve grascii_standard metric

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,8 @@
   or were removed
 - `DictionaryBuilder.build` takes `infiles` and `output` arguments and returns
   a `BuildSummary`
+- Updated the `grascii_standard` metric to incorporate the position and length
+  of the matched grascii
 
 ### Removed
 

--- a/grascii/regen.py
+++ b/grascii/regen.py
@@ -138,6 +138,9 @@ class RegexBuilder:
         builder = list("^")
         i = 0
         if self.search_mode is SearchMode.MATCH or self.search_mode is SearchMode.START:
+            # start the matched_grascii group
+            builder.append("(?P<matched_grascii>")
+
             # match up to two aspirates at the beginning of a word
             if self.aspirate_mode is Strictness.LOW:
                 for j in range(2):
@@ -155,6 +158,9 @@ class RegexBuilder:
         elif self.search_mode is SearchMode.CONTAIN:
             # match any characters up to the end of the grascii word
             builder.append(r"\S*")
+
+            # start the matched_grascii group
+            builder.append("(?P<matched_grascii>")
 
         found_first = False
 
@@ -241,6 +247,9 @@ class RegexBuilder:
             ):
                 builder.append(disjoiner)
                 builder.append("?")
+
+        # end the matched_grascii group
+        builder.append(")")
 
         if self.search_mode is SearchMode.MATCH:
             # match the end of the word/line

--- a/tests/dictionaries/sort.txt
+++ b/tests/dictionaries/sort.txt
@@ -1,0 +1,36 @@
+ABSOL Absolve
+ABSS Abscess
+ABS Absence
+ABSTMUS Abstemious
+
+PAMAS Paymaster
+AMAS Amass
+TASKMAS Taskmaster
+MAS Mass
+
+RELEF Relief
+RELAPS Relapse
+RELEZSH Realization
+RELES Release
+RELESB Releasable
+RAREF Rarefy
+RELAXSH Relaxation
+
+STA~D Starred
+STAD Staid
+TA~DE| Tardily
+SETADL Citadel
+STADEM Stadium
+TA~DEN Tardiness
+DASTA~DE Dastardly
+KUSTA~D Custard
+
+PO,EM Poem
+POES Poise
+PO,ESE Poesy
+PO,ETRE Poetry
+SPOEL Spoil
+POESN Poison
+POENANT Poignant
+SPOELR Spoiler
+POENANSE Poignancy

--- a/tests/test_searchers.py
+++ b/tests/test_searchers.py
@@ -10,17 +10,24 @@ from grascii.parser import InvalidGrascii
 from grascii.searchers import GrasciiSearcher, RegexSearcher, ReverseSearcher
 
 output_dir = "tests/dictionaries/tosearch"
+sorted_output_dir = "test/dictionaries/sorted"
+
+
+def build_dictionary(src, dest):
+    rmtree(dest, ignore_errors=True)
+    infiles = [Path(src)]
+    builder = DictionaryBuilder()
+    builder.build(infiles=infiles, output=DictionaryOutputOptions(dest))
 
 
 def setUpModule():
-    rmtree(output_dir, ignore_errors=True)
-    infiles = [Path("tests/dictionaries/search.txt")]
-    builder = DictionaryBuilder()
-    builder.build(infiles=infiles, output=DictionaryOutputOptions(output_dir))
+    build_dictionary("tests/dictionaries/search.txt", output_dir)
+    build_dictionary("tests/dictionaries/sort.txt", sorted_output_dir)
 
 
 def tearDownModule():
     rmtree(output_dir, ignore_errors=True)
+    rmtree(sorted_output_dir, ignore_errors=True)
 
 
 class TestGrasciiSearcher(unittest.TestCase):
@@ -80,6 +87,105 @@ class TestGrasciiSearcher(unittest.TestCase):
     def test_dictionary_not_found(self):
         with self.assertRaises(DictionaryNotFound):
             GrasciiSearcher(dictionaries=[":should-not-exist"])
+
+
+class TestSortedGrasciiSearches(unittest.TestCase):
+    def test_shorter_grascii_first(self):
+        searcher = GrasciiSearcher(dictionaries=[sorted_output_dir])
+        results = searcher.sorted_search(grascii="ABS", search_mode="start")
+        self.assertListEqual(
+            [r.entry.grascii for r in results],
+            [
+                "ABS",
+                "ABSS",
+                "ABSOL",
+                "ABSTMUS",
+            ],
+        )
+
+    def test_smaller_offset_match_first(self):
+        searcher = GrasciiSearcher(dictionaries=[sorted_output_dir])
+        results = searcher.sorted_search(grascii="MAS", search_mode="contain")
+        self.assertListEqual(
+            [r.entry.grascii for r in results],
+            [
+                "MAS",
+                "AMAS",
+                "PAMAS",
+                "TASKMAS",
+            ],
+        )
+
+    def test_better_matches_first(self):
+        searcher = GrasciiSearcher(dictionaries=[sorted_output_dir])
+        results = searcher.sorted_search(
+            grascii="RELES", search_mode="contain", uncertainty=1
+        )
+        self.assertListEqual(
+            [r.entry.grascii for r in results],
+            [
+                "RELES",
+                "RELESB",
+                "RELEZSH",
+                "RELEF",
+                "RELAPS",
+                "RELAXSH",
+                "RAREF",
+            ],
+        )
+
+    def test_major_annotation_differences_appear_later(self):
+        searcher = GrasciiSearcher(dictionaries=[sorted_output_dir])
+        results = searcher.sorted_search(grascii="TAD", search_mode="contain")
+        self.assertListEqual(
+            [r.entry.grascii for r in results],
+            [
+                "STAD",
+                "STADEM",
+                "SETADL",
+                "TA~DE|",
+                "TA~DEN",
+                "STA~D",
+                "KUSTA~D",
+                "DASTA~DE",
+            ],
+        )
+
+    def test_minor_annotation_differences_special_handling(self):
+        searcher = GrasciiSearcher(dictionaries=[sorted_output_dir])
+        results = searcher.sorted_search(grascii="PO-E", search_mode="contain")
+        self.assertListEqual(
+            [r.entry.grascii for r in results],
+            [
+                "POES",
+                "POESN",
+                "POENANT",
+                "POENANSE",
+                "PO,EM",
+                "PO,ESE",
+                "PO,ETRE",
+                "SPOEL",
+                "SPOELR",
+            ],
+        )
+
+    def test_exact_matches_appear_on_top(self):
+        searcher = GrasciiSearcher(dictionaries=[sorted_output_dir])
+        results = searcher.sorted_search(grascii="PO,E", search_mode="contain")
+        self.assertListEqual(
+            [r.entry.grascii for r in results],
+            [
+                "PO,EM",
+                "PO,ESE",
+                "PO,ETRE",
+                "POES",
+                "POESN",
+                "POENANT",
+                "POENANSE",
+                "SPOEL",
+                "SPOELR",
+            ],
+        )
 
 
 class TestReverseSearcher(unittest.TestCase):


### PR DESCRIPTION
This PR improves the `grascii_standard` metric by taking into account the position and length of the matched grascii.

"start" and "contain" grascii searches are now sorted similarly to reverse searches.

Closes #73 