### PR TITLE
Improve and fixup GrasciiInterpreter

### DIFF
--- a/docs/interpretation.rst
+++ b/docs/interpretation.rst
@@ -80,8 +80,8 @@ canonical interpretation:
 
    **Example**: ``NTN`` is ``N-TN``, not ``NT-N``.
 
-   **Why**: Gregg Shorthand Preanniversary Manual (1916), Lesson 8, General
-   Exercise, Note (b):
+   **Why**: Gregg Shorthand Preanniversary Manual (1916), Seventh Lesson,
+   General Exercise, Note (b):
 
      Where it is possble to use either *ten*, *den*, or *ent*, *end*, the *ten*,
      *den* blend is given the preference.

--- a/grascii/grammars/grascii.lark
+++ b/grascii/grammars/grascii.lark
@@ -13,27 +13,17 @@ consonant : standard_consonant
 
 standard_consonant : K | G | R | L | N | M
 	| T | D | P | B | F | V
-	| CH | J | X
+	| CH | J
 
-blended_consonant.20 : _over_blend
-	| _men
-	| _gent
-	| _def
-	| _ses
+blended_consonant.20 : TN | DN | TM | DM
 	| NT | MT | ND | MD
+	| DF | DV | TV
+	| JNT | JND | PND | PNT
+	| MN | MM
 	| DT | TD | DD
+	| ( SS | XS ) direction?
 	| NG | NK
 	| LD
-
-_over_blend.20 : TN | DN | TM | DM
-_men.30 : MN | MM
-_gent.30 : JNT | JND | PND | PNT
-
-_ses : ( SS | XS ) direction?
-
-// this priority? ex. individual NDV
-// what about -ntive? NTV
-_def.-10 : DF | DV | TV
 
 annotatable_consonant : ( directed_consonant | SH ) OBLIQUE? | X direction?
 
@@ -84,10 +74,11 @@ TN : "TN"
 DN : "DN"
 TM : "TM"
 DM : "DM"
-NT : "NT"
-MT : "MT"
-ND : "ND"
-MD : "MD"
+// Prevent matching before N/M so that over blends are preferred
+NT : /NT(?![NM])/
+MT : /MT(?![NM])/
+ND : /ND(?![NM])/
+MD : /MD(?![NM])/
 DF : "DF"
 DV : "DV"
 TV : "TV"

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -18,8 +18,9 @@ class TestGrasciiInterpreter:
     @pytest.mark.parametrize(
         "grascii,expected,preserve_boundaries",
         [
-            ("DTN", ["D", "TN"], False),
+            ("DTN", ["DT", "N"], False),
             ("NDM", ["N", "DM"], False),
+            ("ND-M", ["ND", "M"], False),
             ("TMD", ["TM", "D"], False),
             ("SSH", ["S", "SH"], False),
             ("DTH", ["D", "TH"], False),
@@ -41,10 +42,16 @@ class TestGrasciiInterpreter:
             ("SS", ["SS"], False),
             ("SS)", ["SS", [")"]], False),
             ("SS,", ["S", "S", [","]], False),
+            ("SS),", ["S", "S", [")", ","]], False),
             ("AU)", ["A", "U", [")"]], False),
             ("OE~", ["O", "E", ["~"]], False),
             ("NDT", ["ND", "T"], False),
             ("MMN", ["MM", "N"], False),
+            ("LDN", ["LD", "N"], False),
+            ("TMN", ["TM", "N"], False),
+            ("DDN", ["DD", "N"], False),
+            ("NDV", ["ND", "V"], False),
+            ("NTDN", ["NT", "DN"], False),
         ],
     )
     def test_interpreter(
@@ -58,3 +65,32 @@ class TestGrasciiInterpreter:
         except InvalidGrascii:
             parser_result = None
         assert parser_result == expected
+
+    # def test_dictionary(self, interpreter, parser):
+    #     from grascii.dictionary.build import DictionaryBuilder
+    #     from pathlib import Path
+    #
+    #     def inter(grascii, transalation, _):
+    #         interpreter_result = interpreter.interpret(grascii, True)
+    #
+    #         try:
+    #             parser_result = next(parser.interpret(grascii, True))
+    #         except InvalidGrascii:
+    #             parser_result = None
+    #
+    #         if interpreter_result != parser_result:
+    #             failures.append([interpreter_result, parser_result])
+    #
+    #         return grascii, transalation
+    #
+    #     failures = []
+    #
+    #     builder = DictionaryBuilder()
+    #     builder = DictionaryBuilder(
+    #         pipeline=[inter]
+    #     )
+    #     inputs = Path("dictionaries/builtins/preanniversary-phrases/").glob("*.txt")
+    #     builder.build(inputs, None)
+    #
+    #     print(failures)
+    #     assert not failures


### PR DESCRIPTION
- Made `GrasciiInterpreter` split the string in a single pass
- Fixed cases in which the interpreter/parser did not following the left-to-right rule for forming multi-character strokes