### PR TITLE
Consider hyphens as word boundaries in reverse searches

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@
 - `grascii dephrase` is a first-class command
 - `dephrase` streams results in a more logical order
 - Added `AU`, `EU`, and `OE` to similarity graph with edge between `AU` and `EU`
+- Reverse search to consider hyphens as word boundaries
 
 ### Removed
 

--- a/grascii/searchers.py
+++ b/grascii/searchers.py
@@ -274,7 +274,7 @@ class ReverseSearcher(RegexSearcher):
         escaped_word = re.escape(word)
         kwargs["regexp"] = (
             r"(?i)(?P<grascii>.+?\s+)"
-            + f"(?P<translation>(.*\\s)?(?P<word>{escaped_word}).*)(\\s|\\Z)"
+            + rf"(?P<translation>(.*(\s|-))?(?P<word>{escaped_word}).*)(\s|\Z)"
         )
 
         return super().search(**kwargs)

--- a/tests/dictionaries/search.txt
+++ b/tests/dictionaries/search.txt
@@ -13,6 +13,7 @@ SABTASH Sabotage
 IN Iron
 FTH Forth
 STN Stun
+SNLO Son-in-law
 SHNT Shunt
 ABTL Abuttal
 BF'ND Beforehand
@@ -33,6 +34,7 @@ CHEPMNK Chipmunk
 A~MAM Armament
 TID Tide
 JENRATR Generator
+LOL Lawless
 FND Found
 'ABT A Habit
 'ABT A Habit Time
@@ -50,3 +52,4 @@ APE~TR Aperture
 ABTM Abutment
 SABTH Sabbath
 FBDN Forbidden
+SVLO Civil Law

--- a/tests/test_searchers.py
+++ b/tests/test_searchers.py
@@ -208,6 +208,11 @@ class TestReverseSearcher(unittest.TestCase):
         result_count = len(searcher.sorted_search(reverse="ag+.*"))
         self.assertEqual(result_count, 0)
 
+    def test_hyphen(self):
+        searcher = ReverseSearcher(dictionaries=[output_dir])
+        result_count = len(searcher.sorted_search(reverse="law"))
+        self.assertEqual(result_count, 3)
+
 
 class TestRegexSeacrher(unittest.TestCase):
     def test_dictionary_not_found(self):


### PR DESCRIPTION
This change allows results to match that contain the search term within a hyphenated word or phrase.

Before:

```
$ grascii search -r law
LO Law
LON Lawn
LOF Lawful
LOR Lawyer
LOL Lawless
LOOD Law And Order
LOMNEUS Lawful Money Of The United States
LOMNEUSA Lawful Money Of The United States Of America
BILO By Law
SVLO Civil Law
TARLO Tariff Law
ATNELO Attorney At Law
KSELLO Counselor At Law
ASMATLO As A Matter Of Law
Results: 14
```

After:

```
$ grascii search -r law
LO Law
LON Lawn
LOF Lawful
LOR Lawyer
LOL Lawless
LOOD Law And Order
LOMNEUS Lawful Money Of The United States
LOMNEUSA Lawful Money Of The United States Of America
BILO By Law
SVLO Civil Law
SNLO Son-in-law
SNLO Son-in-law
TARLO Tariff Law
FATHLO Father-in-law
MUTHLO Mother-in-law
SSTELO Sister-in-law
FATHLO Father-in-law
BRUTH(LO Brother-in-law
BRUTLO Brother-in-law
DTELO Daughter-in-law
ATNELO Attorney At Law
KSELLO Counselor At Law
ASMATLO As A Matter Of Law
Results: 23
```