### PR TITLE
Allow Grascii strings to start with a disjoiner

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - Improved typings for `search` and `dephrase` related functions
+- Allow Grascii strings to start with a disjoiner
 
 ### Removed
 

--- a/grascii/grammars/grascii.lark
+++ b/grascii/grammars/grascii.lark
@@ -1,5 +1,6 @@
 start: _root ( DISJOINER _root ( DISJOINER _root? )? )?
   | _root DISJOINER
+  | DISJOINER _root
   | ASPIRATE
 
 _root : ASPIRATE~0..2 _string ASPIRATE~0..2

--- a/tests/dictionaries/not_grascii.txt
+++ b/tests/dictionaries/not_grascii.txt
@@ -4,7 +4,6 @@ u( under
 high low
 yes no
 win lose
-^i hyper
 valid valid
 away away
 o~, o

--- a/tests/test_dictionary.py
+++ b/tests/test_dictionary.py
@@ -116,7 +116,7 @@ class TestDictionaryBuildWarnings(unittest.TestCase):
             output=DictionaryOutputOptions(self.output_dir),
         )
         self.assertEqual(len(summary.warnings), 0)
-        self.assertEqual(len(summary.errors), 10)
+        self.assertEqual(len(summary.errors), 9)
         for error in summary.errors:
             self.assertEqual(error.level, logging.ERROR)
             self.assertRegex(error.message, "Failed to parse")

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -52,6 +52,8 @@ class TestGrasciiInterpreter:
             ("DDN", ["DD", "N"], False),
             ("NDV", ["ND", "V"], False),
             ("NTDN", ["NT", "DN"], False),
+            ("A^B^", ["A", "^", "B", "^"], True),
+            ("^K", ["^", "K"], True),
         ],
     )
     def test_interpreter(


### PR DESCRIPTION
This PR allows strings that start with a disjoiner (`^`) to be valid Grascii. For example: `^K`

In combination with the new "end" search mode added in #118, this change enables searches for entries that use certain disjoined suffixes.