### PR TITLE
Properly annotate S joined to over/under blends

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Fixed
+
+- `Outline`'s inferred direction annotations of `S` joined to over and under
+   blends
+
 ## 0.9.0 - 2026-04-21
 
 ### Added

--- a/grascii/outline.py
+++ b/grascii/outline.py
@@ -221,6 +221,9 @@ class Outline:
 
         3. In words beginning with IS, the left S is used.
 
+        4. When S is joined to an over blend (TN, DN, TM, DM) or an under blend
+        (NT, ND, MT, MD), the S is used which forms a sharp angle. If a circle
+        vowel occurs between an over blend and the S, the comma S is used.
         """
 
         def set_S_stroke_type(stroke: Stroke) -> None:
@@ -275,6 +278,10 @@ class Outline:
                         # Addendum 3
                         stroke.add_annotation(grammar.LEFT)
                         return
+                if stroke.prev_char.stroke in ("TN", "DN", "TM", "DM"):
+                    # Addendum 4
+                    stroke.add_annotation(grammar.LEFT)
+                    return
                 # Rule 31
                 if set_S_direction_based_on_curves(
                     stroke, stroke.prev_char.tail_type, is_before=False
@@ -305,6 +312,10 @@ class Outline:
                 stroke.add_annotation(grammar.RIGHT)
                 return True
             elif stroke_type.curve == Curve.COUNTER_CLOCKWISE:
+                if stroke_type.direction == Direction.NORTH_EAST and is_before:
+                    # Addendum 4
+                    stroke.add_annotation(grammar.RIGHT)
+                    return True
                 # Rule 30
                 stroke.add_annotation(grammar.LEFT)
                 return True

--- a/tests/test_outline.py
+++ b/tests/test_outline.py
@@ -46,6 +46,10 @@ class TestInferredDirections(unittest.TestCase):
             ("KAS", "KAS)"),
             ("SLA", "S(LA"),
             ("SALS", "S(ALS("),
+            ("DMASK", "DMAS)K"),
+            ("NTESTN", "NTES(TN"),
+            ("SADN", "S)ADN"),
+            ("SANT", "S)ANT"),
         ]
         self.run_tests(tests)
 
@@ -68,6 +72,23 @@ class TestInferredDirections(unittest.TestCase):
 
     def test_s_joined_to_downward_lines(self):
         tests = [("SASH", "S)ASH"), ("SAJ", "S)AJ"), ("CHES", "CHES)")]
+        self.run_tests(tests)
+
+    def test_s_joined_to_consonants(self):
+        tests = [
+            ("SKS", "S)KS)"),
+            ("SRS", "S(RS("),
+            ("SNS", "S)NS("),
+            ("STS", "S)TS("),
+            ("SPS", "S(PS("),
+            ("SFS", "S)FS)"),
+            ("SCHS", "S)CHS)"),
+            ("SNGS", "S)NGS("),
+            ("STNS", "S)TNS("),
+            ("SNTS", "S)NTS("),
+            ("SDFS", "S)DFS)"),
+            ("SJNTS", "S(JNTS("),
+        ]
         self.run_tests(tests)
 
     def test_s_o(self):


### PR DESCRIPTION
S joinings to over and under blends were not properly handled and tested. A new addendum was required.