### PR TITLE
Move var docs to individual members

### DIFF
--- a/grascii/grammar.py
+++ b/grascii/grammar.py
@@ -1,31 +1,4 @@
-"""A collection of useful information about the grascii grammar.
-
-:var STROKES: A set of all valid strokes.
-:var HARD_CHARACTERS: A set of all alphabetic characters that can appear as
-    the first character in a stroke.
-:var ANNOTATION_CHARACTERS: The set of all characters that are annotations.
-:var ASPIRATE: The character corresponding to the aspirate.
-:var MEDIUM_SOUND: The character corresponding to the medium sound of a standard
-    vowel.
-:var LONG_SOUND: The character corresponding to the long sound of a standard
-    vowel.
-:var LOOP: The character corresponding to the loop annotation.
-:var REVERSE: The character corresponding to the reversing annotation.
-:var WUNDERBAR: The character corresponding to the underbar (W) annotation.
-:var ING: The character corresponding to the -ing ending.
-:var LEFT: A character corresponding to a direction annotation.
-:var RIGHT: A character corresponding to a direction annotation.
-:var OBLIQUE: The character corresponding to the oblique annotation.
-:var DISJOINER: The character corresponding to a disjoiner.
-:var BOUNDARY: The character corresponding to a boundary.
-:var INTERSECTION: The character corresponding to an intersection.
-:var ALPHABET: The set of valid characters in the grascii language.
-:var ANNOTATIONS: A dictionary of annotatable strokes to a sequence of
-    acceptable annotations on the corresponding stroke. The sequece contains
-    tuples of annotations. The tuples are ordered in the same order they
-    must appear in a strict grascii string. The tuples contain mutually
-    exclusive annotations. Ex: MEDIUM_SOUND and LONG_SOUND
-"""
+"""A collection of useful information about the Grascii grammar."""
 
 from __future__ import annotations
 
@@ -34,26 +7,45 @@ _STROKES = "A AU A&' A&E B CH D DD DF DM DN DT DV E EU F G I J JND JNT K L LD \
 _VOWELS = "A AU A&' A&E E EU I O OE U"
 
 STROKES = set(_STROKES.split())
+"""A set of all valid strokes."""
 VOWELS = set(_VOWELS.split())
+"""A set of all strokes that represent vowels."""
 CONSONANTS = set(STROKES - VOWELS)
+"""A set of all strokes that represent consonants."""
 
 HARD_CHARACTERS = {c for c in "ABCDEFGIJKLMNOPRSTUVXZ"}
+"""A set of all alphabetic characters that can appear as the first character in a stroke."""
 ANNOTATION_CHARACTERS = {c for c in ",.|~_()"}
+"""The set of all characters that are annotations."""
 ASPIRATE = "'"
+"""The character corresponding to the aspirate."""
 MEDIUM_SOUND = "."
+"""The character corresponding to the medium sound of a standard vowel."""
 LONG_SOUND = ","
+"""The character corresponding to the long sound of a standard vowel. """
 LOOP = "|"
+"""The character corresponding to the loop annotation."""
 REVERSE = "~"
+"""The character corresponding to the reversing annotation."""
 WUNDERBAR = "_"
+"""The character corresponding to the underbar (W) annotation."""
 ING = "'"
+"""The character corresponding to the -ing ending."""
 LEFT = "("
+"""A character corresponding to a direction annotation."""
 RIGHT = ")"
+"""A character corresponding to a direction annotation."""
 OBLIQUE = ","
+"""The character corresponding to the oblique annotation."""
 DISJOINER = "^"
+"""The character corresponding to a disjoiner."""
 BOUNDARY = "-"
+"""The character corresponding to a boundary."""
 INTERSECTION = "\\"
+"""The character corresponding to an intersection."""
 
 ALPHABET = set("ABCDEFGIJKLMNOPRSTUVXZ'.,|~_()^-&\\")
+"""The set of valid characters in the Grascii language."""
 
 _CIRCLE_VOWEL_ANNOTATIONS: list[tuple[str, ...]] = [
     (REVERSE,),
@@ -91,3 +83,10 @@ ANNOTATIONS: dict[str, list[tuple[str, ...]]] = {
     "SS": _DIRECTED_CONSONANT_ANNOTATIONS,
     "XS": _DIRECTED_CONSONANT_ANNOTATIONS,
 }
+"""
+A dictionary of annotatable strokes to a sequence of acceptable annotations on
+the corresponding stroke. The sequence contains tuples of annotations. The
+tuples are ordered in the same order they must appear in a strict Grascii
+string. The tuples contain mutually exclusive annotations. Ex: ``MEDIUM_SOUND``
+and ``LONG_SOUND``
+"""

--- a/grascii/interpreter.py
+++ b/grascii/interpreter.py
@@ -1,11 +1,3 @@
-"""
-:type Interpretation:
-    Represents an interpretation of a Grascii string. An ``Interpretation`` is
-    a list of strokes and annotation lists. Each stroke is its own element in
-    the interpretation, while sequences of annotations are grouped into their
-    own sublist.
-"""
-
 from __future__ import annotations
 
 import re
@@ -15,14 +7,13 @@ from grascii import grammar
 from grascii.validator import GrasciiValidator
 
 Interpretation = list[str | list[str]]
-
-
 """
-A dictionary of multi-character strokes to exception patterns.
-A matching sequence of characters in the Grascii string is treated as the
-corresponding multi-character stroke unless following characters match the
-exception pattern.
+Represents an interpretation of a Grascii string. An ``Interpretation`` is
+a list of strokes and annotation lists. Each stroke is its own element in
+the interpretation, while sequences of annotations are grouped into their
+own sublist.
 """
+
 _EXCEPTIONS = {
     "EU": "[).,]",
     "AU": "[).,]",
@@ -37,6 +28,12 @@ _EXCEPTIONS = {
     "SS": "H|[)(]?,",
     "XS": "H|[)(]?,",
 }
+"""
+A dictionary of multi-character strokes to exception patterns.
+A matching sequence of characters in the Grascii string is treated as the
+corresponding multi-character stroke unless following characters match the
+exception pattern.
+"""
 
 
 class GrasciiInterpreter:


### PR DESCRIPTION
This PR moves documentation for variables from the module docstring to individual docstrings on each variable. This improves the generated documentation.