### PR TITLE
Fix ranking of search results containing A&' or A&E

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - `Outline`'s inferred direction annotations of `S` joined to over and under
    blends
+- Ranking of search results containing `A&'` or `A&E`
 
 ## 0.9.0 - 2026-04-21
 

--- a/grascii/metrics.py
+++ b/grascii/metrics.py
@@ -4,7 +4,6 @@ Contains metrics for comparing search queries to regular expression matches.
 
 from __future__ import annotations
 
-import string
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -73,9 +72,9 @@ def match_to_gsequence(match: Match[str]) -> GrasciiSequence:
             continue
         if group is None:
             continue
-        i = 0
-        while i < len(group) and group[i] in string.ascii_uppercase:
-            i += 1
+        i = len(group)
+        while i >= 0 and group[i - 1] in grammar.ANNOTATION_CHARACTERS:
+            i -= 1
         if i > 0:
             sequence.append(AnnotatedStroke(group[:i], set(group[i:])))
         else:

--- a/tests/dictionaries/sort.txt
+++ b/tests/dictionaries/sort.txt
@@ -34,3 +34,7 @@ POESN Poison
 POENANT Poignant
 SPOELR Spoiler
 POENANSE Poignancy
+
+TOLRANT Tolerant
+MSKRA&'NT Miscreant
+RAND Rained

--- a/tests/test_searchers.py
+++ b/tests/test_searchers.py
@@ -190,6 +190,20 @@ class TestSortedGrasciiSearches(unittest.TestCase):
             ],
         )
 
+    def test_exact_matches_appear_on_top_2(self):
+        searcher = GrasciiSearcher(dictionaries=[sorted_output_dir])
+        results = searcher.sorted_search(
+            grascii="RA&'NT", search_mode="end", uncertainty=1
+        )
+        self.assertListEqual(
+            [r.entry.grascii for r in results],
+            [
+                "MSKRA&'NT",
+                "RAND",
+                "TOLRANT",
+            ],
+        )
+
 
 class TestReverseSearcher(unittest.TestCase):
     def test_results(self):


### PR DESCRIPTION
A bug in `match_to_gsequence` would convert "A&'" or "A&E" to the stroke "A" with annotations. Thus, when the produced GrasciiSequence was compared to an interpretation using the standard metric, its distance would be incorrect. This incorrect distance could lead to the search result appearing too high or low in the sorted result list.