### PR TITLE
Export more types at the package level

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 
 - `interpret` command to interpret Grascii strings
+- Classes and types used by the public APIs as importable from the top-level
+  `grascii`
 
 ### Fixed
 

--- a/grascii/__init__.py
+++ b/grascii/__init__.py
@@ -4,34 +4,55 @@ from __future__ import annotations
 APP_NAME = "grascii"
 __version__ = "0.9.0"
 
+from grascii.dictionary import Dictionary, DictionaryEntry, DictionaryType
 from grascii.dictionary.build import (
     BuildMessage,
     BuildSummary,
     DictionaryBuilder,
     DictionaryOutputOptions,
 )
-from grascii.dictionary.pipeline import PipelineFunc
-from grascii.interpreter import GrasciiInterpreter, interpretation_to_string
+from grascii.dictionary.pipeline import CancelPipeline, PipelineFunc
+from grascii.interpreter import (
+    GrasciiInterpreter,
+    Interpretation,
+    interpretation_to_string,
+)
 from grascii.parser import GrasciiParser, InvalidGrascii
 from grascii.regen import SearchMode, Strictness
-from grascii.searchers import GrasciiSearcher, RegexSearcher, ReverseSearcher, Searcher
+from grascii.searchers import (
+    GrasciiSearcher,
+    GrasciiSearchOptions,
+    RegexSearcher,
+    ReverseSearcher,
+    Searcher,
+    SearcherOptions,
+    SearchResult,
+)
 from grascii.validator import GrasciiValidator
 
 __all__ = [
+    "Dictionary",
+    "DictionaryEntry",
+    "DictionaryType",
     "BuildMessage",
     "BuildSummary",
     "DictionaryBuilder",
     "DictionaryOutputOptions",
+    "CancelPipeline",
     "PipelineFunc",
     "GrasciiInterpreter",
+    "Interpretation",
     "interpretation_to_string",
     "GrasciiParser",
     "InvalidGrascii",
     "SearchMode",
     "Strictness",
     "GrasciiSearcher",
+    "GrasciiSearchOptions",
     "RegexSearcher",
     "ReverseSearcher",
     "Searcher",
+    "SearcherOptions",
+    "SearchResult",
     "GrasciiValidator",
 ]


### PR DESCRIPTION
Most of these types are used directly or indirectly by the existing exported APIs.