### PR TITLE
Prevent searches ending with A from matching A&'/A&E

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@
 - `Outline`'s inferred direction annotations of `S` joined to over and under
    blends
 - Ranking of search results containing `A&'` or `A&E`
+- Potential incorrect results for start/contain searches that ended with `A`
 
 ## 0.9.0 - 2026-04-21
 

--- a/grascii/regen.py
+++ b/grascii/regen.py
@@ -87,6 +87,10 @@ class RegexBuilder:
         if stroke.endswith("S") or stroke.endswith("T"):
             stroke += "(?!H)"
 
+        # Prevent A from matching A&' or A&E
+        if stroke == "A":
+            stroke += "(?!&)"
+
         if (
             self.annotation_mode is Strictness.MEDIUM
             or self.annotation_mode is Strictness.HIGH

--- a/tests/test_regen.py
+++ b/tests/test_regen.py
@@ -49,7 +49,7 @@ class TestAnnotationRegex(unittest.TestCase):
             ("I", ""),
             ("I", "~"),
             ("I", "_"),
-            ("I~|_"),
+            ("I", "~|_"),
         ]
         self.check_strictness_low(annotations, texts)
 
@@ -60,14 +60,14 @@ class TestAnnotationRegex(unittest.TestCase):
             ["_"],
         ]
         texts = [
+            ("A&'", ""),
+            ("A&'", "~"),
+            ("A&'", "_"),
+            ("A&'", "~_"),
             ("A&E", ""),
             ("A&E", "~"),
             ("A&E", "_"),
-            ("A&E~_"),
-            ("A'E", ""),
-            ("A'E", "~"),
-            ("A'E", "_"),
-            ("A'E~_"),
+            ("A&E", "~_"),
         ]
         self.check_strictness_low(annotations, texts)
 
@@ -1502,6 +1502,7 @@ class TestNegativeLookaheads(RegexBuilderTester):
             ([["DT"], [("DT", True), ("EDTS", True), ("EDTH", False)]]),
             ([["JNT"], [("JNT", True), ("EJNTS", True), ("EJNTH", False)]]),
             ([["PNT"], [("PNT", True), ("EPNTS", True), ("EPNTH", False)]]),
+            ([["A"], [("A", True), ("A&'", False), ("A&E", False)]]),
         ]
         self.run_tests(builder, tests)
 


### PR DESCRIPTION
Similar to #121, searches ending in `A` could give incorrect results:

```console
$ grascii search -s contain --aspirate-mode retain -g "R'A"
R'ABELET Rehabilitate
TR'A&EDRN Trihedron
Results: 2
```

`TR'A&EDRN` does not match because it has `A&E` not `A`.

A negative lookahead has been added for `A` to prevent these invalid matches.